### PR TITLE
Nest online timeseries

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ nest_humidity_percent{id="abcd1234",label="Living-Room"} 55
 # HELP nest_setpoint_temperature_celsius Setpoint temperature.
 # TYPE nest_setpoint_temperature_celsius gauge
 nest_setpoint_temperature_celsius{id="abcd1234",label="Living-Room"} 18
+# HELP nest_online Is the thermostat online.
+# TYPE nest_online gauge
+nest_online{id="abcd1234",label="Living-Room"} 1
 # HELP nest_up Was talking to Nest API successful.
 # TYPE nest_up gauge
 nest_up 1

--- a/pkg/collectors/nest/nest_test.go
+++ b/pkg/collectors/nest/nest_test.go
@@ -22,6 +22,7 @@ func TestServerResponses(t *testing.T) {
 			want: &Thermostat{
 				ID:           "enterprises/PROJECT_ID/devices/DEVICE_ID",
 				Label:        "Custom Name",
+				Online:       true,
 				AmbientTemp:  float64(20.23999),
 				SetpointTemp: float64(19.17838),
 				Humidity:     float64(57),

--- a/pkg/pronestheus_test.go
+++ b/pkg/pronestheus_test.go
@@ -31,6 +31,7 @@ func TestAllMetrics(t *testing.T) {
 
 	assert.Equal(t, w.Code, http.StatusOK)
 	assert.Contains(t, w.Body.String(), "nest_up 1")
+	assert.Contains(t, w.Body.String(), `nest_online{id="enterprises/PROJECT_ID/devices/DEVICE_ID",label="Custom-Name"} 1`)
 	assert.Contains(t, w.Body.String(), `nest_setpoint_temperature_celsius{id="enterprises/PROJECT_ID/devices/DEVICE_ID",label="Custom-Name"} 19.17838`)
 	assert.Contains(t, w.Body.String(), `nest_ambient_temperature_celsius{id="enterprises/PROJECT_ID/devices/DEVICE_ID",label="Custom-Name"} 20.23999`)
 	assert.Contains(t, w.Body.String(), `nest_humidity_percent{id="enterprises/PROJECT_ID/devices/DEVICE_ID",label="Custom-Name"} 57`)


### PR DESCRIPTION
This commit introduces a new metric -- nest_online -- which is set to 1 when the thermostat is reported as Connectivity: ONLINE.

This commit also stops outputting all other metrics about the thermostat when the thermostat is OFFLINE. When a thermostat is offline, we do not know what mode it is in, what set temperature it has, and what ambient temperature and humidity it sees.