### PR TITLE
Nest Temperature Sensors and outdoor temp from Nest app API (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # ProNestheus
 
-This is a fork of [grdl/pronestheus](https://github.com/grdl/pronestheus) where the maintainers haven't been responding to pull requests since Dec 2022.
+This is a fork of [grdl/pronestheus](https://github.com/grdl/pronestheus) where the maintainers haven't been responding to pull requests since Dec 2022. Regardless, please appreciate the maintainers of `grdl/pronestheus` for what they have built for us.
 
 ![build](https://github.com/klyubin/pronestheus/workflows/build/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/klyubin/pronestheus)](https://goreportcard.com/report/github.com/klyubin/pronestheus)
 
-A Prometheus exporter for the [Nest Learning Thermostat](https://nest.com/). Exposes metrics about your thermostats and the weather in your current location.
+A Prometheus exporter for the [Nest Learning Thermostat](https://nest.com/). Exposes metrics about your thermostats, temperature sensors, and the weather in your current location.
 
 Works with the new [Google Smart Device Management API](https://developers.google.com/nest/device-access)!
 
 ![dashboard](docs/dashboard.png)
 
 ## Installation
+
+### Build from source
+
+All you need is the Golang toolchain:
+```
+cd cmd/pronestheus
+go build .
+```
+
+You can also cross-compile for a different platform this way. For example, here's how to build for
+an ARM64 Linux target, such as a Raspberry Pi:
+```
+cd cmd/pronestheus
+GOOS=linux GOARCH=arm64 go build .
+```
 
 ### Binary download
 
@@ -60,6 +75,12 @@ Flags:
                                  Device Access Project ID.
       --nest-refresh-token=NEST-REFRESH-TOKEN  
                                  Refresh token
+      --nest-google-auth-url=NEST-GOOGLE-AUTH-URL
+                                 Google auth URL for access to the Nest app. Optional: only needed for scraping Nest Temperature Sensors.
+                                 Optional: only needed for scraping Nest Temperature Sensors and the outside temperatures reported by the Nest App.
+      --nest-google-auth-cookies=NEST-GOOGLE-AUTH-COOKIES
+                                 Cookies for the Google auth URL for access to the Nest app.
+                                 Optional: only needed for scraping Nest Temperature Sensors and the outside temperatures reported by the Nest App.
       --[no-]nest-label-spaces-to-dashes
                                  Whether to replace spaces with dashes in Nest thermostat label.
                                  Default: do not replace.
@@ -74,6 +95,8 @@ Flags:
 
 ### Authentication
 
+#### Nest API
+
 To be able to call the Nest API you need to register for Device Access with Google (there's a one-time $5 fee) and follow [the Get Started guide](https://developers.google.com/nest/device-access/get-started) to create a Device Access project and OAuth2 client.
 
 Then, follow the [Authorize the account guide](https://developers.google.com/nest/device-access/authorize) to get the necessary values for:
@@ -84,6 +107,58 @@ Then, follow the [Authorize the account guide](https://developers.google.com/nes
 
 Because ProNestheus is meant to run continuously, it doesn't require OAuth2 Access Token, only the Refresh Token. It will automatically get the valid access token and refresh it when needed.
 
+
+#### Nest App API
+
+Google's Device Access API does not expose information about Nest Temperature Sensors. If you want
+to get information from your Nest Temperature Sensors and the outside temperature readings reported
+by the Nest app, this scraper can try to gather this information by accessing the API used by the
+Nest app. Beware that this hacky approach is not guaranteed to continue working and requires Google
+Account cookies which cannot be scoped so that only the Nest-related information can be accessed
+using those cookies.
+
+The approach for obtaining access to the API used by the Nest app and the detailed instructions for
+obtaining the credentials was borrowed from
+[chrisjshull/homebridge-nest](https://github.com/chrisjshull/homebridge-nest). Thank you very much!
+
+In short, you will need to sign in into https://home.nest.com in Chrome and grab the
+**user-specific** authentication URL and the cookies used with that URL and provide them to
+ProNestheus via two command-line arguments or their environment variable counterparts.
+These values look something like this:
+
+URL:
+```
+https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&response_type=token%20id_token&login_hint=REDACTED&client_id=REDACTED.apps.googleusercontent.com&origin=https%3A%2F%2Fhome.nest.com&scope=openid%20profile%20email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account&ss_domain=https%3A%2F%2Fhome.nest.com&include_granted_scopes=true&auto=0
+```
+
+Cookies:
+```
+NID=REDACTED; __Secure-3PSID=REDACTED; __Secure-3PAPISID=REDACTED; __Host-3PLSID=REDACTED; __Secure-3PSIDCC=REDACTED
+```
+
+**BEWARE: These cookies, once stolen, provide possibly full access to your Google Account, and not
+just the information from your Nest app. If you're worried about this, create a separate Google
+Account and give it access to your Nest(s) -- by sharing the respective "Home" in the Nest app or
+the Google Home app with this new account. Then use that account's auth URL and cookies in the
+instructions below. You should also consider passing in the URL and the cookies not as commmand-line
+parameters but as the respective environment variables (see `--help`) to reduce the opportunities
+for their leakage.**
+
+1. Open a Chrome browser tab in Incognito Mode (or clear your cache).
+2. Open Developer Tools (Ctrl+Shift+C or, on macOS, Cmd+Shift+C).
+3. Click on 'Network' tab. Make sure 'Preserve Log' is checked.
+4. In the 'Filter' box, enter `issueToken`
+5. Go to `home.nest.com`, and click 'Sign in with Google'. Sign in into your account.
+6. One network call (beginning with `iframerpc`) will appear in the Dev Tools window. Click on it.
+7. In the Headers tab, under General, copy the entire `Request URL` (beginning with `https://accounts.google.com`). This is your `--nest-google-auth-url` command-line parameter (don't forget to quote it because of all the special characters).
+8. In the 'Filter' box, enter `oauth2/iframe`
+9. Several network calls will appear in the Dev Tools window. Click on the last `iframe` call.
+10. In the Headers tab, under Request Headers, copy the entire `cookie` (**include the whole string which is several lines long and has many field/value pairs** - do not include the `cookie:` name). This is your `--nest-google-auth-cookies` command-line parameter (don't forget to quote it because of all the special characters).
+11. Do not log out of `home.nest.com`, as this will invalidate your credentials. Just close the browser tab.
+12. These credentials appear to be valid for about a year. Just repeat this procedure a year later.
+
+
+#### OpenWeatherMap API
 
 OpenWeatherMap API key is required to call the weather API. [Look here](https://openweathermap.org/appid) for instructions on how to get it.
 
@@ -118,6 +193,15 @@ nest_online{id="abcd1234",label="Living Room",room="Living Room"} 1
 # HELP nest_up Was talking to Nest API successful.
 # TYPE nest_up gauge
 nest_up 1
+# HELP nest_temp_sensor_temperature_celsius Temperature Sensor temperature
+# TYPE nest_temp_sensor_temperature_celsius gauge
+nest_temp_sensor_temperature_celsius{serial="22AA01AC123456AB",structure="Home",where="Living Room"} 22
+# HELP nest_temp_sensor_battery Temperature Sensor battery level (0-100)
+# TYPE nest_temp_sensor_battery gauge
+nest_temp_sensor_battery{serial="22AA01AC123456AB",structure="Home",where="Living Room"} 79
+# HELP nest_outside_temperature_celsius Outside temperature
+# TYPE nest_outside_temperature_celsius gauge
+nest_outside_temperature_celsius{id="40e8bbfc-f0b4-4d08-861b-2424f5de7d19",name="Home"} 27.8
 # HELP nest_weather_humidity_percent Outside humidity.
 # TYPE nest_weather_humidity_percent gauge
 nest_weather_humidity_percent 82

--- a/cmd/pronestheus/main.go
+++ b/cmd/pronestheus/main.go
@@ -24,6 +24,8 @@ var cfg = &pkg.ExporterConfig{
 	NestOAuthClientSecret: kingpin.Flag("nest-client-secret", "OAuth2 Client Secret.").String(),
 	NestProjectID:         kingpin.Flag("nest-project-id", "Device Access Project ID.").String(),
 	NestRefreshToken:      kingpin.Flag("nest-refresh-token", "Refresh token").String(),
+	NestGoogleAuthURL:     kingpin.Flag("nest-google-auth-url", "Google auth URL for access to the Nest app. Optional: only needed for scraping Nest Temperature Sensors and the outside temperatures reported by the Nest App.").String(),
+	NestGoogleAuthCookies: kingpin.Flag("nest-google-auth-cookies", "Cookies for the Google auth URL for access to the Nest app. Optional: only needed for scraping Nest Temperature Sensors and the outside temperatures reported by the Nest App.").String(),
 	NestLabelSpaceToDash:  kingpin.Flag("nest-label-spaces-to-dashes", "Replace spaces with dashes in Nest thermostat label").Bool(),
 	WeatherURL:            kingpin.Flag("owm-url", "The OpenWeatherMap API URL.").Default("http://api.openweathermap.org/data/2.5/weather").String(),
 	WeatherToken:          kingpin.Flag("owm-auth", "The authorization token for OpenWeatherMap API.").String(),

--- a/pkg/collectors/nestapp/nestapp.go
+++ b/pkg/collectors/nestapp/nestapp.go
@@ -1,0 +1,384 @@
+package nestapp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	errNon200Response      = errors.New("nest app API responded with non-200 code")
+	errFailedUnmarshalling = errors.New("failed unmarshalling Nest app API response body")
+	errFailedRequest       = errors.New("failed Nest app API request")
+	errFailedReadingBody   = errors.New("failed reading Nest app API response body")
+)
+
+// Config provides the configuration necessary to create the Collector.
+type Config struct {
+	Logger      log.Logger
+	Timeout     int
+	AuthURL     string
+	AuthCookies string
+}
+
+// Collector implements the Collector interface, collecting thermostats data from Nest app API.
+type Collector struct {
+	config                Config
+	client                *http.Client
+	accessToken           string
+	accessTokenValidUntil time.Time
+	userId                string
+	logger                log.Logger
+	metrics               *Metrics
+}
+
+// Metrics contains the metrics collected by the Collector.
+type Metrics struct {
+	up           *prometheus.Desc
+	temp         *prometheus.Desc
+	batteryLevel *prometheus.Desc
+	outsideTemp  *prometheus.Desc
+}
+
+// New creates a Collector using the given Config.
+func New(cfg Config) (*Collector, error) {
+	client := &http.Client{}
+	client.Timeout = time.Duration(cfg.Timeout) * time.Millisecond
+
+	collector := &Collector{
+		config:  cfg,
+		client:  client,
+		logger:  cfg.Logger,
+		metrics: buildMetrics(),
+	}
+
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Timeout)*time.Millisecond)
+	defer cancel()
+	err := collector.reauth(ctxTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to authenticate to Nest API: %w", err)
+	}
+
+	return collector, nil
+}
+
+func (c *Collector) reauth(ctx context.Context) error {
+	googleAccessToken, err := c.getGoogleAccessToken(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to get Google Account access token: %w", err)
+	}
+	jwt, userId, jwtExpirationInstant, err := c.getNestJwt(ctx, googleAccessToken)
+	if err != nil {
+		return fmt.Errorf("Failed to get Nest access token: %w", err)
+	}
+
+	c.accessToken = jwt
+	c.userId = userId
+	c.accessTokenValidUntil = jwtExpirationInstant
+	c.logger.Log("level", "debug", "message", fmt.Sprintf("Obtained new access token for API used by the Nest app. Valid until %s", jwtExpirationInstant.String()))
+	return nil
+}
+
+func (c *Collector) getGoogleAccessToken(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.config.AuthURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed to create GET request: %w", err)
+	}
+	req.Header.Set("Cookie", c.config.AuthCookies)
+	req.Header.Set("X-Requested-With", "XmlHttpRequest")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("Request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read response body: %w", err)
+	}
+
+	bodyString := string(body)
+	if errorId := gjson.Get(bodyString, "error"); errorId.Exists() {
+		return "", fmt.Errorf("%s: %s", errorId.String(), gjson.Get(bodyString, "error_description").String())
+	}
+
+	accessToken := gjson.Get(bodyString, "access_token").String()
+	if accessToken == "" {
+		return "", fmt.Errorf("No access token in the response")
+	}
+
+	return accessToken, nil
+}
+
+func (c *Collector) getNestJwt(ctx context.Context, googleAccessToken string) (string, string, time.Time, error) {
+	requestBody := fmt.Sprintf(`{"embed_google_oauth_access_token": true,
+"expire_after": "3600s",
+"google_oauth_access_token": "%s",
+"policy_id": "authproxy-oauth-policy"
+}`, googleAccessToken)
+	req, err := http.NewRequestWithContext(ctx,
+		"POST",
+		"https://nestauthproxyservice-pa.googleapis.com/v1/issue_jwt",
+		bytes.NewReader([]byte(requestBody)))
+	if err != nil {
+		return "", "", time.Now(), fmt.Errorf("Failed to create POST request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", googleAccessToken))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Requested-With", "XmlHttpRequest")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", "", time.Now(), fmt.Errorf("Request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", time.Now(), fmt.Errorf("Failed to read response body: %w", err)
+	}
+
+	bodyString := string(body)
+	if errorId := gjson.Get(bodyString, "error"); errorId.Exists() {
+		return "", "", time.Now(), fmt.Errorf("%s: %s", errorId.String(), gjson.Get(bodyString, "error_description").String())
+	}
+
+	jwt := gjson.Get(bodyString, "jwt").String()
+	if jwt == "" {
+		return "", "", time.Now(), fmt.Errorf("No JWT in the response: %s", bodyString)
+	}
+
+	userId := gjson.Get(bodyString, "claims").Get("subject").Get("nestId").Get("id").String()
+	if userId == "" {
+		return "", "", time.Now(), fmt.Errorf("No user ID (claims.subject.nestId.id) in the response: %s", bodyString)
+	}
+
+	expirationStr := gjson.Get(bodyString, "claims").Get("expirationTime").String()
+	if expirationStr == "" {
+		return "", "", time.Now(), fmt.Errorf("No access token expiration time (claims.expirationTime) in the response: %s", bodyString)
+	}
+
+	expirationInstant, err := time.Parse(time.RFC3339, expirationStr)
+	if err != nil {
+		return "", "", time.Now(), fmt.Errorf("Failed to parse access token expiration time (%s): %w", expirationStr, err)
+	}
+
+	return jwt, userId, expirationInstant, nil
+}
+
+func buildMetrics() *Metrics {
+	var sensorLabels = []string{"serial", "structure", "where"}
+	var structureLabels = []string{"id", "name"}
+	return &Metrics{
+		up:           prometheus.NewDesc("nest_app_up", "Was talking to Nest app API successful.", nil, nil),
+		temp:         prometheus.NewDesc("nest_temp_sensor_temperature_celsius", "Temperature Sensor temperature", sensorLabels, nil),
+		batteryLevel: prometheus.NewDesc("nest_temp_sensor_battery", "Temperature Sensor battery level (0-100)", sensorLabels, nil),
+		outsideTemp:  prometheus.NewDesc("nest_outside_temperature_celsius", "Outside temperature", structureLabels, nil),
+	}
+}
+
+// Describe implements the prometheus.Describe interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.metrics.up
+	ch <- c.metrics.temp
+	ch <- c.metrics.batteryLevel
+	ch <- c.metrics.outsideTemp
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	readings, err := c.getReadings()
+	if err != nil {
+		ch <- prometheus.MustNewConstMetric(c.metrics.up, prometheus.GaugeValue, 0)
+		c.logger.Log("level", "error", "message", "Failed collecting Nest app data", "stack", errors.WithStack(err))
+		return
+	}
+
+	c.logger.Log("level", "debug", "message", "Successfully collected Nest app data")
+
+	ch <- prometheus.MustNewConstMetric(c.metrics.up, prometheus.GaugeValue, 1)
+
+	for _, sensor := range readings.sensors {
+		labels := []string{sensor.SerialNumber, sensor.StructureName, sensor.WhereName}
+
+		ch <- prometheus.MustNewConstMetric(c.metrics.temp, prometheus.GaugeValue, sensor.Temperature, labels...)
+		ch <- prometheus.MustNewConstMetric(c.metrics.batteryLevel, prometheus.GaugeValue, float64(sensor.BatteryLevel), labels...)
+	}
+
+	for _, structure := range readings.structures {
+		labels := []string{structure.Id, structure.Name}
+		if !math.IsNaN(structure.OutsideTemperature) {
+			ch <- prometheus.MustNewConstMetric(c.metrics.outsideTemp, prometheus.GaugeValue, structure.OutsideTemperature, labels...)
+		}
+	}
+}
+
+type NestTemperatureSensor struct {
+	SerialNumber  string
+	StructureName string
+	WhereName     string
+	LastUpdatedAt time.Time
+	Temperature   float64
+	BatteryLevel  int64
+}
+
+type Structure struct {
+	Id                 string
+	Name               string
+	WhereNames         map[string]string
+	OutsideTemperature float64
+}
+
+type Readings struct {
+	structures []Structure
+	sensors    []NestTemperatureSensor
+}
+
+func (c *Collector) getReadings() (readings *Readings, err error) {
+	// Try to re-authenticate and obtain a new access token if the current one is about to expire
+	// or has expired.
+	if !time.Now().Before(c.accessTokenValidUntil.Add(-2 * time.Minute)) {
+		// Access token about to expire or already expired
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Duration(c.config.Timeout)*time.Millisecond)
+		defer cancel()
+		err := c.reauth(ctxTimeout)
+		if err != nil {
+			// Error out only if the current token expired.
+			if !time.Now().Before(c.accessTokenValidUntil) {
+				return nil, fmt.Errorf("Failed to re-authenticate to Nest API: %w", err)
+			}
+		}
+	}
+	// We probably have a valid accecss token -- use it
+
+	// Ask the Nest App API for the information on structures, locations, and the Temperature
+	// Sensors ("kryptonite").
+	reqBody := "{\"known_bucket_types\":[\"structure\",\"where\",\"kryptonite\"],\"known_bucket_versions\":[]}"
+	req, err := http.NewRequest("POST",
+		fmt.Sprintf("https://home.nest.com/api/0.1/user/%s/app_launch", c.userId),
+		bytes.NewReader([]byte(reqBody)))
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s", c.accessToken))
+	req.Header.Set("Cookie", fmt.Sprintf("G_ENABLED_IDPS=google; eu_cookie_accepted=1; viewer-volume=0.5; cztoken=%s; user_token=%s", c.accessToken, c.accessToken))
+	req.Header.Set("X-nl-user-id", c.userId)
+	req.Header.Set("X-nl-protocol-version", "1")
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(errFailedRequest, err.Error())
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, errors.Wrap(errNon200Response, fmt.Sprintf("code: %d", res.StatusCode))
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(errFailedReadingBody, err.Error())
+	}
+
+	// Populate our "structures" map from the returned "structure" and "where" objects.
+	structures := make(map[string]Structure)
+	gjson.Get(string(body), "updated_buckets").ForEach(func(_, obj gjson.Result) bool {
+		objKey := obj.Get("object_key").String()
+		if strings.HasPrefix(objKey, "structure.") {
+			if v := obj.Get("value"); v.Exists() {
+				id := strings.TrimPrefix(objKey, "structure.")
+				structures[id] = Structure{
+					Id:                 id,
+					Name:               v.Get("name").String(),
+					WhereNames:         make(map[string]string),
+					OutsideTemperature: math.NaN(),
+				}
+			}
+		}
+		return true
+	})
+	gjson.Get(string(body), "updated_buckets").ForEach(func(_, obj gjson.Result) bool {
+		objKey := obj.Get("object_key").String()
+		if strings.HasPrefix(objKey, "where.") {
+			if v := obj.Get("value"); v.Exists() {
+				id := strings.TrimPrefix(objKey, "where.")
+				structure, found := structures[id]
+				if found {
+					v.Get("wheres").ForEach(func(_, obj gjson.Result) bool {
+						if whereId := obj.Get("where_id"); whereId.Exists() {
+							structure.WhereNames[whereId.String()] = obj.Get("name").String()
+						}
+						return true
+					})
+				}
+			}
+		}
+		return true
+	})
+
+	// Populate our "sensors" list from the returned "kryptonite" objects.
+	sensors := make([]NestTemperatureSensor, 0)
+	gjson.Get(string(body), "updated_buckets").ForEach(func(_, obj gjson.Result) bool {
+		objKey := obj.Get("object_key").String()
+		if strings.HasPrefix(objKey, "kryptonite.") {
+			if v := obj.Get("value"); v.Exists() {
+				structure := structures[v.Get("structure_id").String()]
+				sensors = append(sensors, NestTemperatureSensor{
+					SerialNumber:  v.Get("serial_number").String(),
+					LastUpdatedAt: time.Unix(v.Get("last_updated_at").Int(), 0),
+					Temperature:   v.Get("current_temperature").Float(),
+					BatteryLevel:  v.Get("battery_level").Int(),
+					StructureName: structure.Name,
+					WhereName:     structure.WhereNames[v.Get("where_id").String()],
+				})
+			}
+		}
+		return true
+	})
+
+	// Populate the outside temperature for each structure from the returned weather info.
+	if weatherForStructures := gjson.Get(string(body), "weather_for_structures"); weatherForStructures.Exists() {
+		weatherForStructures.ForEach(func(key, value gjson.Result) bool {
+			if strings.HasPrefix(key.String(), "structure.") {
+				structureId := strings.TrimPrefix(key.String(), "structure.")
+				structure, found := structures[structureId]
+				if found {
+					if current := value.Get("current"); current.Exists() {
+						if tempC := current.Get("temp_c"); tempC.Exists() {
+							structure.OutsideTemperature = tempC.Float()
+							structures[structureId] = structure
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	structuresList := make([]Structure, 0)
+	for _, structure := range structures {
+		structuresList = append(structuresList, structure)
+	}
+	return &Readings{
+		structures: structuresList,
+		sensors:    sensors,
+	}, nil
+}
+
+func b2f(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
This adds support for obtaining the information from Nest Temperature Sensors (temperature, battery level, serial number) and about the outside temperature from the API used by the Nest app. For example:

```
 # HELP nest_temp_sensor_temperature_celsius Temperature Sensor temperature
 # TYPE nest_temp_sensor_temperature_celsius gauge
nest_temp_sensor_temperature_celsius{serial="22AA01AC123456AB",structure="Home",where="Living Room"} 22
 # HELP nest_temp_sensor_battery Temperature Sensor battery level (0-100)
 # TYPE nest_temp_sensor_battery gauge
nest_temp_sensor_battery{serial="22AA01AC123456AB",structure="Home",where="Living Room"} 79
 # HELP nest_outside_temperature_celsius Outside temperature
 # TYPE nest_outside_temperature_celsius gauge
nest_outside_temperature_celsius{id="40e8bbfc-f0b4-4d08-861b-2424f5de7d19",name="Home"} 27.8
```

This hacky way (not guaranteed to continue working and requires Google Account cookies instead of something more sensible such as what's used used by the Google Device Access API) is used because the official Google Device Access API does not expose information about users' Nest Temperature Sensors.